### PR TITLE
Issue38

### DIFF
--- a/common/header.php
+++ b/common/header.php
@@ -95,7 +95,7 @@
     .show-advanced.button:after {
       background-color: <?php echo($secondaryBrandColor); ?>;
     }
-    .hTagcloud input[type=checkbox] + label::before {
+    .hTagcloud li  {
       color: <?php echo($linkColor); ?>;
     }
     #multi-tag-submit a {

--- a/common/header.php
+++ b/common/header.php
@@ -98,7 +98,7 @@
     .hTagcloud li  {
       color: <?php echo($linkColor); ?>;
     }
-    #multi-tag-submit a {
+    #multi-tag-submit button {
       border-color: <?php echo($secondaryBrandColor); ?>;
       background-color: <?php echo($brandColor); ?>;
       color: <?php echo($headerTextColor); ?>;

--- a/css/screen.css
+++ b/css/screen.css
@@ -1203,6 +1203,10 @@ table.item-metadata th {
   content: "";
 }
 
+.hTagcloud input:focus + label {
+  text-decoration: underline;
+}
+
 #multi-tag-submit {
   text-align: center;
   margin-top: 3em;

--- a/css/screen.css
+++ b/css/screen.css
@@ -1191,20 +1191,6 @@ table.item-metadata th {
   line-height: normal;
 }
 
-input.multi-tag {
-  border: 0 !important;
-  clip: rect(1px, 1px, 1px, 1px) !important;
-  -webkit-clip-path: inset(50%) !important;
-  clip-path: inset(50%) !important;
-  height: 1px !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  padding: 0 !important;
-  position: absolute !important;
-  width: 1px !important;
-  white-space: nowrap !important;
-}
-
 .hTagcloud input[type=checkbox] + label::before {
   content: "";
   font-family: "FontAwesome";
@@ -1222,7 +1208,7 @@ input.multi-tag {
   margin-top: 3em;
 }
 
-#multi-tag-submit a {
+#multi-tag-submit button {
   border-width: 2px;
   border-style: solid;
   border-radius: 5px;
@@ -2080,6 +2066,20 @@ nav a:hover {
 
 div.pagination {
   width: 100%;
+}
+
+.visually-hidden {
+  border: 0 !important;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  -webkit-clip-path: inset(50%) !important;
+  clip-path: inset(50%) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+  white-space: nowrap !important;
 }
 
 /* @end */

--- a/css/screen.css
+++ b/css/screen.css
@@ -1191,6 +1191,20 @@ table.item-metadata th {
   line-height: normal;
 }
 
+input.multi-tag {
+  border: 0 !important;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  -webkit-clip-path: inset(50%) !important;
+  clip-path: inset(50%) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+  white-space: nowrap !important;
+}
+
 .hTagcloud input[type=checkbox] + label::before {
   content: "";
   font-family: "FontAwesome";
@@ -2066,20 +2080,6 @@ nav a:hover {
 
 div.pagination {
   width: 100%;
-}
-
-.visually-hidden {
-  border: 0 !important;
-  clip: rect(1px, 1px, 1px, 1px) !important;
-  -webkit-clip-path: inset(50%) !important;
-  clip-path: inset(50%) !important;
-  height: 1px !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  padding: 0 !important;
-  position: absolute !important;
-  width: 1px !important;
-  white-space: nowrap !important;
 }
 
 /* @end */

--- a/css/screen.css
+++ b/css/screen.css
@@ -1191,10 +1191,6 @@ table.item-metadata th {
   line-height: normal;
 }
 
-.hTagcloud input[type=checkbox] {
-  display: none;
-}
-
 .hTagcloud input[type=checkbox] + label::before {
   content: "";
   font-family: "FontAwesome";
@@ -2070,6 +2066,20 @@ nav a:hover {
 
 div.pagination {
   width: 100%;
+}
+
+.visually-hidden {
+  border: 0 !important;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  -webkit-clip-path: inset(50%) !important;
+  clip-path: inset(50%) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+  white-space: nowrap !important;
 }
 
 /* @end */

--- a/functions.php
+++ b/functions.php
@@ -414,4 +414,77 @@ function dh_item_image_gallery($attrs = array(), $imageType = 'square_thumbnail'
     return $html;
 }
 
+/**
+ * Create a tag cloud made of divs that follow the hTagcloud microformat
+ *
+ * @package Omeka\Function\View\Tag
+ * @param Omeka_Record_AbstractRecord|array $recordOrTags The record to retrieve
+ * tags from, or the actual array of tags
+ * @param string|null $link The URI to use in the link for each tag. If none
+ * given, tags will be set up with form inputs to enable selecting multiple tags.
+ * This behavior is changed from default, where links are simply removed.
+ * @param int $maxClasses
+ * @param bool $tagNumber
+ * @param string $tagNumberOrder
+ * @return string HTML for the tag cloud
+ */
+function dh_tag_cloud($recordOrTags = null, $link = null, $maxClasses = 9, $tagNumber = false, $tagNumberOrder = null)
+{
+    if (!$recordOrTags) {
+        $tags = array();
+    } elseif (is_string($recordOrTags)) {
+        $tags = get_current_record($recordOrTags)->Tags;
+    } elseif ($recordOrTags instanceof Omeka_Record_AbstractRecord) {
+        $tags = $recordOrTags->Tags;
+    } else {
+        $tags = $recordOrTags;
+    }
+
+    if (empty($tags)) {
+        return '<p>' . __('No tags are available.') . '</p>';
+    }
+
+    //Get the largest value in the tags array
+    $largest = 0;
+    foreach ($tags as $tag) {
+        if ($tag["tagCount"] > $largest) {
+            $largest = $tag['tagCount'];
+        }
+    }
+    $html = '<div class="hTagcloud">';
+    $html .= '<ul class="popularity">';
+
+    if ($largest < $maxClasses) {
+        $maxClasses = $largest;
+    }
+
+    foreach ($tags as $tag) {
+        $size = (int) (($tag['tagCount'] * $maxClasses) / $largest - 1);
+        $class = str_repeat('v', $size) . ($size ? '-' : '') . 'popular';
+        $html .= '<li class="' . $class . '">';
+        if ($link) {
+            $html .= '<a href="' . html_escape(url($link, array('tags' => $tag['name']))) . '">';
+        } else {
+            $html .= '<input type="checkbox" class="multi-tag" name="tags[]" value="' . html_escape($tag['name']) . '" id="' . html_escape($tag['name']) . '">';
+            $html .= '<label for="' . html_escape($tag['name']) . '">';
+        }
+        if ($tagNumber && $tagNumberOrder == 'before') {
+            $html .= ' <span class="count">'.$tag['tagCount'].'</span> ';
+        }
+        $html .= html_escape($tag['name']);
+        if ($tagNumber && $tagNumberOrder == 'after') {
+            $html .= ' <span class="count">'.$tag['tagCount'].'</span> ';
+        }
+        if ($link) {
+            $html .= '</a>';
+        } else {
+            $html .= '</label>';
+        }
+        $html .= '</li>' . "\n";
+    }
+    $html .= '</ul></div>';
+
+    return $html;
+}
+
 ?>

--- a/functions.php
+++ b/functions.php
@@ -465,7 +465,7 @@ function dh_tag_cloud($recordOrTags = null, $link = null, $maxClasses = 9, $tagN
         if ($link) {
             $html .= '<a href="' . html_escape(url($link, array('tags' => $tag['name']))) . '">';
         } else {
-            $html .= '<input type="checkbox" class="multi-tag" name="tags[]" value="' . html_escape($tag['name']) . '" id="' . html_escape($tag['name']) . '">';
+            $html .= '<input type="checkbox" class="multi-tag visually-hidden" name="tags[]" value="' . html_escape($tag['name']) . '" id="' . html_escape($tag['name']) . '">';
             $html .= '<label for="' . html_escape($tag['name']) . '">';
         }
         if ($tagNumber && $tagNumberOrder == 'before') {

--- a/items/tags.php
+++ b/items/tags.php
@@ -23,7 +23,7 @@ echo head(array('title'=>$pageTitle, 'bodyclass'=>'items tags'));
 		var items = jQuery(element_selector);
 		items.each( function() {
 			var tag = jQuery(this).text().replace(" ", "+")
-			jQuery(this).before('<input type="checkbox" class="multi-tag" value="'+tag+'" id="'+tag+'"><label for="'+tag+'"></label>');
+			jQuery(this).before('<input type="checkbox" class="multi-tag visually-hidden" value="'+tag+'" id="'+tag+'"><label for="'+tag+'"></label>');
 		})
 	}
 

--- a/items/tags.php
+++ b/items/tags.php
@@ -19,22 +19,12 @@ echo head(array('title'=>$pageTitle, 'bodyclass'=>'items tags'));
   <form class="" action="browse" method="get">
     <?php echo dh_tag_cloud($tags, null); ?>
     <div id="multi-tag-submit">
-      <button type="button" name="find-selected-tags">Find selected tags</button>
+      <button type="button" name="find-selected-tags">Find items with selected tags</button>
     </div>
   </form>
 </div>
 
 <script type="text/javascript">
-  // TODO: Okay, so the selector is wrong if I turn the links off, and the sizing
-  // also doesn't work, probably on the a not the li
-	function insert_checkboxes(element_selector, form_selector) {
-		var items = jQuery(element_selector);
-		items.each( function() {
-      var name = jQuery(this).text();
-			var tag = name.replace(" ", "+");
-			jQuery(this).before('<input type="checkbox" class="multi-tag" name="tags" value="'+tag+'" id="'+tag+'"><label for="'+tag+'"></label>');
-		})
-	}
 
   jQuery('#multi-tag-submit').click(function() {
     var tags = [];

--- a/items/tags.php
+++ b/items/tags.php
@@ -14,36 +14,38 @@ echo head(array('title'=>$pageTitle, 'bodyclass'=>'items tags'));
 </div>
 
 <?php uasort($tags, function($a, $b) { return strcasecmp($a['name'],$b['name']); }); ?>
-<?php echo tag_cloud($tags, 'items/browse'); ?>
 
-<div id="multi-tag"></div>
+<div id="multi-tag">
+  <form class="" action="browse" method="get">
+    <?php echo dh_tag_cloud($tags, null); ?>
+    <div id="multi-tag-submit">
+      <button type="button" name="find-selected-tags">Find selected tags</button>
+    </div>
+  </form>
+</div>
 
 <script type="text/javascript">
+  // TODO: Okay, so the selector is wrong if I turn the links off, and the sizing
+  // also doesn't work, probably on the a not the li
 	function insert_checkboxes(element_selector, form_selector) {
 		var items = jQuery(element_selector);
 		items.each( function() {
-			var tag = jQuery(this).text().replace(" ", "+")
-			jQuery(this).before('<input type="checkbox" class="multi-tag visually-hidden" value="'+tag+'" id="'+tag+'"><label for="'+tag+'"></label>');
+      var name = jQuery(this).text();
+			var tag = name.replace(" ", "+");
+			jQuery(this).before('<input type="checkbox" class="multi-tag" name="tags" value="'+tag+'" id="'+tag+'"><label for="'+tag+'"></label>');
 		})
 	}
 
-	insert_checkboxes(".hTagcloud li a");
+  jQuery('#multi-tag-submit').click(function() {
+    var tags = [];
+    jQuery(".multi-tag:checked").each(function() {
+      tags.push(jQuery(this).attr('value'));
+    });
+    window.location.href = "browse?tags=" + tags.join(",");
+  });
 
-	var selected_tags = [];
+	// insert_checkboxes(".hTagcloud li");
 
-	jQuery('#multi-tag').append('<div id="multi-tag-submit"><a href="#" >Find selected tags</a></div>')
-
-	jQuery(".multi-tag").on('click', function() {
-		if (jQuery(this).is(":checked")) {
-			selected_tags.push(jQuery(this).attr("value"));
-		} else {
-			var index = selected_tags.indexOf(jQuery(this).attr("value"));
-			if (index > -1) {
-				selected_tags.splice(index, 1);
-			}
-		}
-		jQuery("#multi-tag-submit a").attr("href", "browse?tags="+selected_tags.join(","));
-	})
 </script>
 
 <?php echo foot(); ?>

--- a/sass/breakpoints/_base.scss
+++ b/sass/breakpoints/_base.scss
@@ -268,6 +268,20 @@ div.pagination {
   width: 100%;
 }
 
+.visually-hidden {
+	border: 0 !important;
+	clip: rect(1px, 1px, 1px, 1px) !important;
+	-webkit-clip-path: inset(50%) !important;
+		clip-path: inset(50%) !important;
+	height: 1px !important;
+	margin: -1px !important;
+	overflow: hidden !important;
+	padding: 0 !important;
+	position: absolute !important;
+	width: 1px !important;
+	white-space: nowrap !important;
+}
+
 /* @end */
 /* @group ----- Home Page ----- */
 #home #primary {

--- a/sass/breakpoints/_base.scss
+++ b/sass/breakpoints/_base.scss
@@ -268,20 +268,6 @@ div.pagination {
   width: 100%;
 }
 
-.visually-hidden {
-	border: 0 !important;
-	clip: rect(1px, 1px, 1px, 1px) !important;
-	-webkit-clip-path: inset(50%) !important;
-		clip-path: inset(50%) !important;
-	height: 1px !important;
-	margin: -1px !important;
-	overflow: hidden !important;
-	padding: 0 !important;
-	position: absolute !important;
-	width: 1px !important;
-	white-space: nowrap !important;
-}
-
 /* @end */
 /* @group ----- Home Page ----- */
 #home #primary {

--- a/sass/partials/_items.scss
+++ b/sass/partials/_items.scss
@@ -205,10 +205,6 @@ table.item-metadata th {
   line-height: normal;
 }
 
-.hTagcloud input[type=checkbox] {
-  display: none;
-}
-
 .hTagcloud input[type=checkbox] + label::before {
   content: "\f096";
   font-family: "FontAwesome";

--- a/sass/partials/_items.scss
+++ b/sass/partials/_items.scss
@@ -212,8 +212,13 @@ table.item-metadata th {
   text-align: left;
   display: inline-block;
 }
+
 .hTagcloud input[type=checkbox]:checked + label::before {
   content: "\f046";
+}
+
+.hTagcloud input:focus + label {
+  text-decoration: underline;
 }
 
 #multi-tag-submit {

--- a/sass/partials/_items.scss
+++ b/sass/partials/_items.scss
@@ -205,20 +205,6 @@ table.item-metadata th {
   line-height: normal;
 }
 
-input.multi-tag {
-	border: 0 !important;
-	clip: rect(1px, 1px, 1px, 1px) !important;
-	-webkit-clip-path: inset(50%) !important;
-		clip-path: inset(50%) !important;
-	height: 1px !important;
-	margin: -1px !important;
-	overflow: hidden !important;
-	padding: 0 !important;
-	position: absolute !important;
-	width: 1px !important;
-	white-space: nowrap !important;
-}
-
 .hTagcloud input[type=checkbox] + label::before {
   content: "\f096";
   font-family: "FontAwesome";
@@ -235,7 +221,7 @@ input.multi-tag {
   margin-top: 3em;
 }
 
-#multi-tag-submit a {
+#multi-tag-submit button {
   border-width: 2px;
   border-style: solid;
   border-radius: 5px;

--- a/sass/partials/_items.scss
+++ b/sass/partials/_items.scss
@@ -205,6 +205,20 @@ table.item-metadata th {
   line-height: normal;
 }
 
+input.multi-tag {
+	border: 0 !important;
+	clip: rect(1px, 1px, 1px, 1px) !important;
+	-webkit-clip-path: inset(50%) !important;
+		clip-path: inset(50%) !important;
+	height: 1px !important;
+	margin: -1px !important;
+	overflow: hidden !important;
+	padding: 0 !important;
+	position: absolute !important;
+	width: 1px !important;
+	white-space: nowrap !important;
+}
+
 .hTagcloud input[type=checkbox] + label::before {
   content: "\f096";
   font-family: "FontAwesome";


### PR DESCRIPTION
Fix for tag cloud accessibility. Inputs are hidden visually, but not removed from the DOM, and focus is indicated when tabbing through inputs. JS was also updated: previous functionality was to add selections to an array upon selection, then search for the array upon clicking button, but this was a dumb idea on my part. Instead the button just checks for which inputs are checked, which is better for things like clicking back and finding inputs still selected.