### PR TITLE
Issue37

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -119,11 +119,6 @@ display_footer_copyright.type = "checkbox"
 display_footer_copyright.options.label = "Display Copyright in Footer"
 display_footer_copyright.options.description = "Check this box if you wish to display your site's copyright information in the footer."
 
-use_advanced_search.type = "checkbox"
-use_advanced_search.options.label = "Use Advanced Site-wide Search"
-use_advanced_search.options.description = "Check this box if you wish to allow users to search your whole site by record (i.e. item, collection, file) and choose their boolean method."
-use_advanced_search.value = "1"
-
 browse_item_title.type = "text"
 browse_item_title.options.label = "Browse Item Page Title"
 browse_item_title.options.description = "Replace the title of the Browse Item page with a title of your choosing. If left blank, this defaults to 'Browse Items'."

--- a/css/screen.css
+++ b/css/screen.css
@@ -870,21 +870,7 @@ header:after {
   border: 0;
   right: 0;
   top: 0;
-  width: 30px;
-  text-indent: -9999px;
-}
-
-#search-container button:after {
-  font-family: "FontAwesome";
-  content: "";
-  text-indent: 0;
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 30px;
-  line-height: 30px;
-  text-align: center;
-  width: 30px;
+  width: 5em;
 }
 
 .show-advanced.button {
@@ -1879,6 +1865,10 @@ p, ul, ol, dl {
 
 ul ul, ul ol, ol ol, ol ul {
   margin-bottom: 0;
+}
+
+button#submit_search {
+  font-family: "Droid Sans", sans-serif;
 }
 
 /* -- Misc Inline elements -- */

--- a/sass/breakpoints/_base.scss
+++ b/sass/breakpoints/_base.scss
@@ -81,6 +81,10 @@ ul ul, ul ol, ol ol, ol ul {
   margin-bottom: 0;
 }
 
+button#submit_search {
+  font-family: $droid_sans;
+}
+
 /* -- Misc Inline elements -- */
 em, i {
   font-style: italic;

--- a/sass/partials/_header.scss
+++ b/sass/partials/_header.scss
@@ -89,21 +89,21 @@ header:after {
   border: 0;
   right: 0;
   top: 0;
-  width: 30px;
-  text-indent: -9999px;
+  width: 5em;
+  // text-indent: -9999px;
 }
-#search-container button:after {
-  font-family: "FontAwesome";
-  content: "\f002";
-  text-indent: 0;
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 30px;
-  line-height: 30px;
-  text-align: center;
-  width: 30px;
-}
+// #search-container button:after {
+//   font-family: "FontAwesome";
+//   content: "\f002";
+//   text-indent: 0;
+//   position: absolute;
+//   top: 0;
+//   left: 0;
+//   height: 30px;
+//   line-height: 30px;
+//   text-align: center;
+//   width: 30px;
+// }
 
 #search-container button:hover, .show-advanced.button:hover:after {
 }

--- a/sass/partials/_header.scss
+++ b/sass/partials/_header.scss
@@ -90,20 +90,7 @@ header:after {
   right: 0;
   top: 0;
   width: 5em;
-  // text-indent: -9999px;
 }
-// #search-container button:after {
-//   font-family: "FontAwesome";
-//   content: "\f002";
-//   text-indent: 0;
-//   position: absolute;
-//   top: 0;
-//   left: 0;
-//   height: 30px;
-//   line-height: 30px;
-//   text-align: center;
-//   width: 30px;
-// }
 
 #search-container button:hover, .show-advanced.button:hover:after {
 }


### PR DESCRIPTION
This is a fix for #37. It removes the magnifying glass icon from the search button and replaces it with "Search" as text as a simple accessibility fix. The previous way of hiding the text threw off focus indication substantially in Firefox, and the icon doesn't add much. This also disables the advanced search option, as it doesn't function in a very accessible way, is buried pretty deep in Omeka, and is not as good as the search done by our elasticsearch plugin.