### PR TITLE
removed h4 from exhibit title in nav

### DIFF
--- a/exhibit-builder/exhibits/show.php
+++ b/exhibit-builder/exhibits/show.php
@@ -6,7 +6,7 @@ echo head(array(
 ?>
 
 <nav id="exhibit-pages">
-    <h4><?php echo exhibit_builder_link_to_exhibit($exhibit); ?></h4>
+    <p><?php echo exhibit_builder_link_to_exhibit($exhibit); ?></p>
     <?php echo exhibit_builder_page_tree($exhibit, $exhibit_page); ?>
 </nav>
 


### PR DESCRIPTION
replaced with simple p tag, doesn't significantly change appearance but removes the possibility of mismatched header levels.

Fix for #41 